### PR TITLE
Allow specifying a pseudo random generator at generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ markov.buildCorpus()
 
 const options = {
   maxTries: 20, // Give up if I don't have a sentence after 20 tries (default is 10)
+  prng: Math.random, // An external Pseudo Random Number Generator if you want to get seeded results
   filter: (result) => {
     return
       result.string.split(' ').length >= 5 && // At least 5 words
@@ -129,11 +130,16 @@ Since `.generate()` can potentially take several seconds or more, a non-blocking
 ```ts
 {
   maxTries: number // The max number of tentatives before giving up (default is 10)
+  prng: Math.random, // An external Pseudo Random Number Generator if you want to get seeded results
   filter: (result: MarkovResult) => boolean // A callback to filter results (see example above)
 }
 ```
 
 ## Changelog
+
+#### 2.1.0
+
+- Add an optionnal `prng` parameter at generation to use a specific Pseudo Random Number Generator
 
 #### 2.0.4
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 export declare type MarkovGenerateOptions = {
     maxTries?: number;
+    prng?: any;
     filter?: (result: MarkovResult) => boolean;
 };
 export declare type MarkovConstructorOptions = {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,10 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const lodash_1 = require("lodash");
+function sampleWithPRNG(array, prng = Math.random) {
+    const length = array == null ? 0 : array.length;
+    return length ? array[Math.floor(prng() * length)] : undefined;
+}
 class Markov {
     /**
      * Creates an instance of Markov generator.
@@ -116,18 +120,19 @@ class Markov {
         }
         const corpus = lodash_1.cloneDeep(this.corpus);
         const maxTries = options.maxTries ? options.maxTries : 10;
+        const prng = options.prng ? options.prng : Math.random;
         let tries;
         // We loop through fragments to create a complete sentence
         for (tries = 1; tries <= maxTries; tries++) {
             let ended = false;
             // Create an array of MarkovCorpusItems
             // The first item is a random startWords element
-            const arr = [lodash_1.sample(this.startWords)];
+            const arr = [sampleWithPRNG(this.startWords, prng)];
             let score = 0;
             // loop to build a complete sentence
             for (let innerTries = 0; innerTries < maxTries; innerTries++) {
                 const block = arr[arr.length - 1]; // last value in array
-                const state = lodash_1.sample(corpus[block.words]); // Find a following item in the corpus
+                const state = sampleWithPRNG(corpus[block.words], prng); // Find a following item in the corpus
                 // If a state cannot be found, the sentence can't be completed
                 if (!state) {
                     break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markov-strings",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "A Markov string generator",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
-import { assignIn, cloneDeep, flatten, includes, isEmpty, isString, sample, slice, some, uniqBy } from 'lodash'
+import { assignIn, cloneDeep, flatten, includes, isEmpty, isString, slice, some, uniqBy } from 'lodash'
+
+function sampleWithPRNG (array: Array<any>, prng: any = Math.random) {
+  const length = array == null ? 0 : array.length
+  return length ? array[Math.floor(prng() * length)] : undefined
+}
 
 export type MarkovGenerateOptions = {
-  maxTries?: number
+  maxTries?: number,
+  prng?: any,
   filter?: (result: MarkovResult) => boolean
 }
 
@@ -146,6 +152,7 @@ export default class Markov {
 
     const corpus = cloneDeep(this.corpus)
     const maxTries = options.maxTries ? options.maxTries : 10
+    const prng = options.prng ? options.prng : Math.random
 
     let tries: number
 
@@ -155,14 +162,14 @@ export default class Markov {
 
       // Create an array of MarkovCorpusItems
       // The first item is a random startWords element
-      const arr = [sample(this.startWords)!]
+      const arr = [sampleWithPRNG(this.startWords, prng)!]
 
       let score = 0
 
       // loop to build a complete sentence
       for (let innerTries = 0; innerTries < maxTries; innerTries++) {
         const block = arr[arr.length - 1] // last value in array
-        const state = sample(corpus[block.words]) // Find a following item in the corpus
+        const state = sampleWithPRNG(corpus[block.words], prng) // Find a following item in the corpus
 
         // If a state cannot be found, the sentence can't be completed
         if (!state) {


### PR DESCRIPTION
I needed to control the entropy of the generated sentences, so I replace the `sample` method from lodash to a custom implementation, which can take a third parameter being a function returning a float between 0 and 1.

In usage, this modification allows to use a seeded PRNG.